### PR TITLE
Removed if trigger causing all megas to be considered ruined

### DIFF
--- a/common/scripted_triggers/giga_mega_categories.txt
+++ b/common/scripted_triggers/giga_mega_categories.txt
@@ -696,15 +696,10 @@ gigas_ruined_megas_list = {
 third_party_ruined_megas_list = {
 	[[$CONDITION$]]
 	or = {
-		if = {
-			limit = {
-				has_global_flag = has_guillis_planet_modifiers_mod
-			}
-			$CONDITION$ = gpm_refinery_ruined
-			$CONDITION$ = gpm_mining_facility_ruined
-			$CONDITION$ = gpm_observation_station_ruined
-			$CONDITION$ = gpm_silo_ruined
-		}
+		$CONDITION$ = gpm_refinery_ruined
+		$CONDITION$ = gpm_mining_facility_ruined
+		$CONDITION$ = gpm_observation_station_ruined
+		$CONDITION$ = gpm_silo_ruined
 	}
 }
 


### PR DESCRIPTION
For some reason if triggers with a false limit will evaluate to true; previous state resulted in all megastructures being considered ruined unless Guilli's planetary modifiers was present